### PR TITLE
Fix macos scenelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ You would also need to made entries in your system process manager (systemd, ups
 start the uWSGI server on boot.
 
 ## Change Notes
+###### Version 2.9.2 (December 2015)
+* fixed bug with scene list submission generated on MacOS
 
 ###### Version 2.9.1 (December 2015)
 * added additional reports

--- a/web/ordering/views.py
+++ b/web/ordering/views.py
@@ -175,7 +175,9 @@ class NewOrder(AbstractView):
 
         if not self.input_product_list:
             if 'input_product_list' in request.FILES:
-                _ipl = request.FILES['input_product_list'].read().split('\n')
+                _ipl_str = request.FILES['input_product_list'].read()
+                _splitter = "\n" if "\n" in _ipl_str else "\r"
+                _ipl = _ipl_str.split(_splitter)
                 self.input_product_list = _ipl
 
         retval = collections.namedtuple("InputProductListResult",


### PR DESCRIPTION
fixed ```\r``` separated scenes in addition to ```\n``` separated items