### PR TITLE
LSRD 738 - address security scan risks

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -20,6 +20,7 @@ espaweb.config.from_envvar('ESPAWEB_SETTINGS', silent=False)
 espaweb.secret_key = espaweb.config['SECRET_KEY']
 espaweb.config['SESSION_TYPE'] = 'memcached'
 espaweb.config['PERMANENT_SESSION_LIFETIME'] = timedelta(minutes=120)
+espaweb.config['SESSION_COOKIE_SECURE'] = True
 
 Session(espaweb)
 api_base_url = "http://{0}:{1}/api/{2}".format(espaweb.config['APIHOST'],

--- a/src/app.py
+++ b/src/app.py
@@ -19,6 +19,7 @@ espaweb = Flask(__name__)
 espaweb.config.from_envvar('ESPAWEB_SETTINGS', silent=False)
 espaweb.secret_key = espaweb.config['SECRET_KEY']
 espaweb.config['SESSION_TYPE'] = 'memcached'
+espaweb.config['SESSION_PERMANENT'] = False
 espaweb.config['PERMANENT_SESSION_LIFETIME'] = timedelta(minutes=120)
 espaweb.config['SESSION_COOKIE_SECURE'] = True
 

--- a/src/app.py
+++ b/src/app.py
@@ -491,6 +491,12 @@ def console_config():
 def admin_update(action, orderid):
     return api_up('/{}/{}'.format(action, orderid), {}, 'put').text
 
+
+@espaweb.after_request
+def apply_xframe_options(response):
+    response.headers['X-Frame-Options'] = 'DENY'
+    return response
+
 if __name__ == '__main__':
     debug = False
     if 'ESPA_DEBUG' in os.environ and os.environ['ESPA_DEBUG'] == 'True':


### PR DESCRIPTION
* Adds `X-Frame-Options: DENY` to all response headers (modern browser support against clickjacking)
* Forces all cookies to go across using SSL only (`Set-Cookie: Secure;` header)
* Forces cookies to expire on browser close 