### PR TITLE
LSRD-887: popup warn cfmask orders

### DIFF
--- a/src/static/js/new_order.js
+++ b/src/static/js/new_order.js
@@ -53,6 +53,7 @@ var meters = "meters";
 var show_hide_delay = 200;
 
 var statistics = "#include_statistics";
+var cfmask = "#include_cfmask";
 
 
 $(document).ready(function(){
@@ -84,6 +85,20 @@ $(document).ready(function(){
 
    $("input:radio[name='output_format']").filter("[value=gtiff]").click();
 
+
+
+   /*******************************************************************
+       TODO: Change this to disable cfmask completely
+   *******************************************************************/
+    $(cfmask).click(function(item) {
+        var cfmaskpopup="#cfmask_popup";
+        if ( $(cfmaskpopup).is(":hidden") ) {
+            $(cfmaskpopup).dialog({
+                height: 200, width: 500,
+                title: 'Notice of Upcoming Product Deprecation'
+            });
+       }
+    });
 
    /*******************************************************************
        Event handling for displaying/hiding the available input product

--- a/src/static/js/new_order.js
+++ b/src/static/js/new_order.js
@@ -92,11 +92,13 @@ $(document).ready(function(){
    *******************************************************************/
     $(cfmask).click(function(item) {
         var cfmaskpopup="#cfmask_popup";
-        if ( $(cfmaskpopup).is(":hidden") ) {
+        if ( $(cfmaskpopup).is(":hidden") && $(cfmask).is(':checked') ) {
             $(cfmaskpopup).dialog({
                 height: 200, width: 500,
                 title: 'Notice of Upcoming CFMask Discontinuation'
             });
+       } else {
+            $(cfmaskpopup).dialog('close')
        }
     });
 

--- a/src/static/js/new_order.js
+++ b/src/static/js/new_order.js
@@ -95,7 +95,7 @@ $(document).ready(function(){
         if ( $(cfmaskpopup).is(":hidden") ) {
             $(cfmaskpopup).dialog({
                 height: 200, width: 500,
-                title: 'Notice of Upcoming Product Deprecation'
+                title: 'Notice of Upcoming CFMask Discontinuation'
             });
        }
     });

--- a/src/templates/new_order.html
+++ b/src/templates/new_order.html
@@ -282,8 +282,10 @@
 					<label class="tooltip" title="Generate Intercomparision Statistics and Plots" for="include_statistics">Plot Output Product Statistics</label>
 				</div>
 				<div id="cfmask_popup" style="display:none; background-color: #ffa64d;">
-					On June 2nd, Users will no longer be able to order CFMask processing from Collection-01 inputs.
-					Users can use the <a href="https://landsat.usgs.gov/collectionqualityband">Pixel QA</a> product (already included with all outputs)
+					Starting June 2, 2017, users will no longer be able to order CFMask processing for Landsat Collection 1 Higher-Level data products.
+					Equivalent information is now available in the pixel_qa band, which is included with all Higher-Level products.
+					For more information on the pixel_qa band, see the Product Characteristics sections of the <a href="https://landsat.usgs.gov/sites/default/files/documents/ledaps_product_guide.pdf">Landsat 4-7</a>
+					and <a href="https://landsat.usgs.gov/sites/default/files/documents/lasrc_product_guide.pdf">Landsat 8</a> Surface Reflectance Product Guides.
 				</div>
 			</div>
 		</div>

--- a/src/templates/new_order.html
+++ b/src/templates/new_order.html
@@ -281,6 +281,10 @@
 					<input class="product" type="checkbox" id="include_statistics" name="plot_statistics"></input>
 					<label class="tooltip" title="Generate Intercomparision Statistics and Plots" for="include_statistics">Plot Output Product Statistics</label>
 				</div>
+				<div id="cfmask_popup" style="display:none; background-color: #ffa64d;">
+					On June 2nd, Users will no longer be able to order CFMask processing from Collection-01 inputs.
+					Users can use the <a href="https://landsat.usgs.gov/collectionqualityband">Pixel QA</a> product (already included with all outputs)
+				</div>
 			</div>
 		</div>
 


### PR DESCRIPTION
In June 2017, CFMask will no longer be an orderable product through ESPA for Landsat Collection 01 products. 

Here is a demo of the quick temporary bother-box for the users: 
![screencapture](https://cloud.githubusercontent.com/assets/4110571/25868193/7a0e4508-34c1-11e7-92bb-2aa892d4617e.gif)
